### PR TITLE
Update github/codeql-action/upload-sarif to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: haskell-actions/setup@v2 # GHC is neneded in $PATH
+      - uses: haskell-actions/setup@v2 # GHC is needed in $PATH
         with:
           ghc-version: '9.8'
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
         cat results.sarif
     - name: Upload SARIF file
       id: upload-sarif
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.checkout_path }}/results.sarif
         category: haskell-security-action


### PR DESCRIPTION
This remove 2 warnings I [found in logs](https://github.com/dancewithheart/agda2scala/actions/runs/24686937272):
```text
Node.js 20 actions are deprecated. The  following actions are running on Node.js 20 and may not work as  expected: github/codeql-action/upload-sarif@v3. 
...
CodeQL Action v3 will be deprecated in  December 2026. Please update all occurrences of the CodeQL Action in  your workflow files to v4.
```
Change was tested by running action from branch:
```yaml
      - name: Run Haskell Security Action
        uses: dancewithheart/haskell-security-action@fix-warnings
```
output without warnings is [here](https://github.com/dancewithheart/agda2scala/actions/runs/24691279968).